### PR TITLE
Bug fix updates for FastQTL

### DIFF
--- a/easybuild/easyconfigs/f/FastQTL/FastQTL-2.184-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/FastQTL/FastQTL-2.184-foss-2015b.eb
@@ -11,7 +11,7 @@ sources = ['%(name)s-%(version)s.linux.tgz']
 patches = ['%(name)s-%(version)s.patch']
 checksums = [
     '98a9ba48e82a62956fc27a58d040d7bf',  # FastQTL-2.184.linux.tgz
-    '7b8cd0068a4d4d577c659d8c021846f9',  # FastQTL-2.184.patch
+    'de08ae24a2bdad7aa65f2a32f739d392',  # FastQTL-2.184.patch
 ]
 
 toolchain = {'name': 'foss', 'version': '2015b'}

--- a/easybuild/easyconfigs/f/FastQTL/FastQTL-2.184.patch
+++ b/easybuild/easyconfigs/f/FastQTL/FastQTL-2.184.patch
@@ -35,7 +35,7 @@ diff -ru FastQTL.org/lib/Tabix/Makefile FastQTL.patched/lib/Tabix/Makefile
  		javac -cp .:sam.jar TabixReader.java
 diff -ru FastQTL.org/Makefile FastQTL.patched/Makefile
 --- FastQTL.org/Makefile	2015-06-23 12:45:11.000000000 +0200
-+++ FastQTL.patched/Makefile	2017-11-06 13:59:19.000000000 +0100
++++ FastQTL.patched/Makefile	2017-12-24 00:11:13.000000000 +0100
 @@ -1,5 +1,5 @@
  #PLEASE SPECIFY THE R path here where you built the R math library standalone 
 -RMATH=~/Software/R-3.1.3/src
@@ -43,11 +43,13 @@ diff -ru FastQTL.org/Makefile FastQTL.patched/Makefile
  
  #compiler
  CXX=g++
-@@ -28,7 +28,7 @@
+@@ -27,8 +27,8 @@
+ 
  #libraries
  #LIB_BASE=-lm -lboost_iostreams -lboost_program_options -lz -lgsl -lblas
- LIB_BASE=-lm -lz -lboost_iostreams -lboost_program_options -lgsl -lblas
+-LIB_BASE=-lm -lz -lboost_iostreams -lboost_program_options -lgsl -lblas
 -LIB_MATH=$(RMATH)/nmath/standalone/libRmath.a
++LIB_BASE=-lm -lz -lboost_iostreams -lboost_program_options -lgslcblas -lgsl -lopenblas
 +LIB_MATH=$(RMATH)/lib64/libRmath.a
  LIB_TABX=$(PATH_TABX)/libtabix.a
  LIB_MACX=-L/usr/local/lib/

--- a/easybuild/easyconfigs/f/FastQTL/FastQTL-v7-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/FastQTL/FastQTL-v7-foss-2015b.eb
@@ -11,7 +11,7 @@ sources = ['%(version)s.tar.gz']
 patches = ['%(name)s-%(version)s.patch']
 checksums = [
     '6456b3c79472fed4c8563f8dcc533a80',  # v7.tar.gz
-    '214c034d2cd3fccd29f57aa08240e8c2',  # FastQTL-v7.patch
+    'c85c4e4ac22fdd94cdf94e2c463d478d',  # FastQTL-v7.patch
 ]
 
 toolchain = {'name': 'foss', 'version': '2015b'}

--- a/easybuild/easyconfigs/f/FastQTL/FastQTL-v7.patch
+++ b/easybuild/easyconfigs/f/FastQTL/FastQTL-v7.patch
@@ -1,4 +1,3 @@
-Only in fastqtl-7.patched/: FastQTL-v7.patch
 diff -ru fastqtl-7.org/lib/Tabix/Makefile fastqtl-7.patched/lib/Tabix/Makefile
 --- fastqtl-7.org/lib/Tabix/Makefile	2017-10-24 23:56:50.000000000 +0200
 +++ fastqtl-7.patched/lib/Tabix/Makefile	2017-11-06 15:33:23.000000000 +0100
@@ -36,7 +35,7 @@ diff -ru fastqtl-7.org/lib/Tabix/Makefile fastqtl-7.patched/lib/Tabix/Makefile
  		javac -cp .:sam.jar TabixReader.java
 diff -ru fastqtl-7.org/Makefile fastqtl-7.patched/Makefile
 --- fastqtl-7.org/Makefile	2017-10-24 23:56:50.000000000 +0200
-+++ fastqtl-7.patched/Makefile	2017-11-06 16:37:21.000000000 +0100
++++ fastqtl-7.patched/Makefile	2017-12-22 17:25:20.000000000 +0100
 @@ -1,5 +1,5 @@
  #PLEASE SPECIFY THE R path here where you built the R math library standalone 
 -RMATH=../../R-3.2.4/src
@@ -44,11 +43,13 @@ diff -ru fastqtl-7.org/Makefile fastqtl-7.patched/Makefile
  
  #compiler
  CXX=g++ -std=c++11
-@@ -28,7 +28,7 @@
+@@ -27,8 +27,8 @@
+ 
  #libraries
  #LIB_BASE=-lm -lboost_iostreams -lboost_program_options -lz -lgsl -lblas
- LIB_BASE=-lm -lz -lbz2 -lboost_iostreams -lboost_program_options -lgslcblas -lgsl -lblas
+-LIB_BASE=-lm -lz -lbz2 -lboost_iostreams -lboost_program_options -lgslcblas -lgsl -lblas
 -LIB_MATH=$(RMATH)/nmath/standalone/libRmath.a
++LIB_BASE=-lm -lz -lbz2 -lboost_iostreams -lboost_program_options -lgslcblas -lgsl -lopenblas
 +LIB_MATH=$(RMATH)/lib64/libRmath.a
  LIB_TABX=$(PATH_TABX)/libtabix.a
  LIB_MACX=-L/usr/local/lib/


### PR DESCRIPTION
* Updated patch for FastQTL-v7 to use OpenBLAS supplied by EB as opposed to system BLAS.