### PR TITLE
Bugfix for RPlus.

### DIFF
--- a/easybuild/easyconfigs/r/RPlus/RPlus-3.6.1-foss-2018b-v19.07.1.eb
+++ b/easybuild/easyconfigs/r/RPlus/RPlus-3.6.1-foss-2018b-v19.07.1.eb
@@ -72,20 +72,6 @@ bioconductor_options = {
 #   * Packages should be specified with fixed versions!
 #
 exts_list = [
-    'base',
-    'compiler',
-    'datasets',
-    'graphics',
-    'grDevices',
-    'grid',
-    'methods',
-    'parallel',
-    'splines',
-    'stats',
-    'stats4',
-    'tcltk',
-    'tools',
-    'utils',
     ('abind', '1.4-5', {
         'source_tmpl': '%(name)s_%(version)s.tar.gz',
         'source_urls': ['http://cran.r-project.org/src/contrib/', 'http://cran.r-project.org/src/contrib/Archive/%(name)s'],

--- a/easybuild/easyconfigs/r/RPlus/RPlus-3.6.1-foss-2018b-v19.07.1.eb
+++ b/easybuild/easyconfigs/r/RPlus/RPlus-3.6.1-foss-2018b-v19.07.1.eb
@@ -3650,7 +3650,11 @@ exts_list = [
     ('xlsx', '0.6.1', {
         'source_tmpl': '%(name)s_%(version)s.tar.gz',
         'source_urls': ['http://cran.r-project.org/src/contrib/', 'http://cran.r-project.org/src/contrib/Archive/%(name)s'],
-        'checksums': ['a580bd16b5477c1c185bf681c12c1ffff4088089f97b6a37997913d93ec5a8b4'],
+        'patches': ['%(name)s_%(version)s.patch'],
+        'checksums': [
+            'a580bd16b5477c1c185bf681c12c1ffff4088089f97b6a37997913d93ec5a8b4', #  xlsx_0.6.1.tar.gz
+            'd763b274088ca8a0e93b4c270c18dfe727af8d6a6e277ca2a90ca3f7730848e5', #  xlsx_0.6.1.patch
+        ],
     }),
     ('zipcode', '1.0', {
         'source_tmpl': '%(name)s_%(version)s.tar.gz',

--- a/easybuild/easyconfigs/r/RPlus/xlsx_0.6.1.patch
+++ b/easybuild/easyconfigs/r/RPlus/xlsx_0.6.1.patch
@@ -1,0 +1,12 @@
+diff -W 308 -ru xlsx.original/R/utilities.R xlsx.patched/R/utilities.R
+--- xlsx.original/R/utilities.R	2018-06-08 03:39:57.000000000 +0200
++++ xlsx.patched/R/utilities.R	2019-08-05 15:29:26.000000000 +0200
+@@ -43,7 +43,7 @@
+   
+   # what's your java  version?  Need > 1.5.0.
+   jversion <- .jcall('java.lang.System','S','getProperty','java.version')
+-  if (jversion < "1.5.0")
++  if (utils::compareVersion(jversion,"1.5.0")<0)
+     stop(paste("Your java version is ", jversion,
+                  ".  Need 1.5.0 or higher.", sep=""))
+   


### PR DESCRIPTION
* Removed base packages from RPlus: no need to recheck them (again) as they are already checked by the EasyConfig for the corresponding R bare.
* Added patch for detecting ```Java``` versions >= 10.x correctly in R package ```xlsx```.