### PR TITLE
Added first version of ngs-bits and bugfix for PythonPlus

### DIFF
--- a/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11-GCCcore-7.3.0.eb
@@ -1,0 +1,45 @@
+easyblock = 'MakeCp'
+
+name = 'ngs-bits'
+version = '2019_11'
+
+homepage = 'https://github.com/imgag/ngs-bits'
+description = """ Short read sequencing tools. """
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+toolchainopts = {'pic': True}
+
+#
+# Example URL: https://github.com/imgag/ngs-bits/releases/download/2019_11/ngs-bits-2019_11.tgz
+#
+source_urls = [('http://github.com/imgag/ngs-bits/releases/download/%s/' % (version))]
+sources = [('%s-%s.tgz' % (name, version))]
+checksums = ['953b6828283e8a01e60a464608a0de8e26de6cf1bf6713f38aeb7167877f9a6c']
+
+osdependencies = [
+    ('qt5-qtbase'),
+    ('qt5-qtbase-devel'),
+]
+
+builddependencies = [
+    ('binutils', '2.30'),
+]
+
+dependencies = [
+    ('PythonPlus', '3.7.4', '-v20.02.1', ('foss', '2018b')),
+    ('cURL', '7.63.0'),
+]
+
+#
+# build according to README.md
+#
+buildopts = ' build_3rdparty && make build_tools_release'
+
+files_to_copy = ['tools' , 'bin' , 'doc' , 'htslib' , 'LICENSE' , 'README.md' ] 
+
+sanity_check_paths = {
+    'files': ['QtCreatorCodingStyle.xml'],
+    'dirs': ['bin', 'tools'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11-GCCcore-7.3.0.eb
@@ -14,7 +14,11 @@ toolchainopts = {'pic': True}
 #
 source_urls = [('http://github.com/imgag/ngs-bits/releases/download/%s/' % (version))]
 sources = [('%s-%s.tgz' % (name, version))]
-checksums = ['953b6828283e8a01e60a464608a0de8e26de6cf1bf6713f38aeb7167877f9a6c']
+patches = [('%s-%s.patch' % (name, version))]
+checksums = [
+    '953b6828283e8a01e60a464608a0de8e26de6cf1bf6713f38aeb7167877f9a6c', #  ngs-bits-2019_11.tgz
+    'b89da731889056139cafcb9f8ad394ded5cb0bd6a2fda9a29ac9e74f1fee9912', #  ngs-bits-2019_11.patch
+]
 
 osdependencies = [
     ('qt5-qtbase'),
@@ -26,20 +30,24 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('PythonPlus', '3.7.4', '-v20.02.1', ('foss', '2018b')),
-    ('cURL', '7.63.0'),
+    ('PCRE', '8.43'),
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.6'),
+    ('XZ', '5.2.4'),
+    ('cURL', '7.63.0'), # For S3 support.
+    ('HTSlib', '1.9'),
 ]
 
 #
 # build according to README.md
 #
-buildopts = ' build_3rdparty && make build_tools_release'
+buildopts = ' build_tools_release'
 
-files_to_copy = ['tools' , 'bin' , 'doc' , 'htslib' , 'LICENSE' , 'README.md' ] 
+files_to_copy = ['bin', 'doc', 'LICENSE', 'README.md']
 
 sanity_check_paths = {
-    'files': ['QtCreatorCodingStyle.xml'],
-    'dirs': ['bin', 'tools'],
+    'files': ['README.md', 'bin/CnvHunter'],
+    'dirs': ['bin', 'doc'],
 }
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11.patch
+++ b/easybuild/easyconfigs/n/ngs-bits/ngs-bits-2019_11.patch
@@ -1,0 +1,62 @@
+diff -ru ngs-bits.original/Makefile ngs-bits.patched/Makefile
+--- ngs-bits.original/Makefile	2019-11-25 15:12:58.000000000 +0000
++++ ngs-bits.patched/Makefile	2020-02-14 21:47:41.006301633 +0000
+@@ -17,7 +17,7 @@
+ build_libs_debug_noclean:
+ 	mkdir -p build-libs-Linux-Debug;
+ 	cd build-libs-Linux-Debug; \
+-		qmake ../src/libs.pro "CONFIG+=debug" "CONFIG-=release"; \
++		qmake-qt5 ../src/libs.pro "CONFIG+=debug" "CONFIG-=release"; \
+ 		make;
+ 
+ clean_libs_debug:
+@@ -28,7 +28,7 @@
+ build_tools_debug_noclean:
+ 	mkdir -p build-tools-Linux-Debug;
+ 	cd build-tools-Linux-Debug; \
+-		qmake ../src/tools.pro "CONFIG+=debug" "CONFIG-=release"; \
++		qmake-qt5 ../src/tools.pro "CONFIG+=debug" "CONFIG-=release"; \
+ 		make;
+ 
+ clean_tools_debug:
+@@ -42,34 +42,34 @@
+ 	rm -rf build-libs-Linux-Release;
+ 	mkdir -p build-libs-Linux-Release;
+ 	cd build-libs-Linux-Release; \
+-		qmake ../src/libs.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/libs.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 
+ build_tools_release:
+ 	rm -rf build-tools-Linux-Release;
+ 	mkdir -p build-tools-Linux-Release;
+ 	cd build-tools-Linux-Release; \
+-		qmake ../src/tools.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/tools.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 
+ build_gui_release:
+ 	rm -rf build-tools_gui-Linux-Release;
+ 	mkdir -p build-tools_gui-Linux-Release;
+ 	cd build-tools_gui-Linux-Release; \
+-		qmake ../src/tools_gui.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/tools_gui.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 
+ build_release_noclean:
+ 	cd build-libs-Linux-Release; \
+-		qmake ../src/libs.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/libs.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 	cd ..
+ 	cd build-tools-Linux-Release; \
+-		qmake ../src/tools.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/tools.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 	cd ..
+ 	cd build-tools_gui-Linux-Release; \
+-		qmake ../src/tools_gui.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
++		qmake-qt5 ../src/tools_gui.pro "CONFIG-=debug" "CONFIG+=release" "DEFINES+=QT_NO_DEBUG_OUTPUT"; \
+ 		make;
+ 	
+ #################################### other targets ##################################

--- a/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.02.1.eb
+++ b/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.02.1.eb
@@ -764,7 +764,7 @@ exts_list = [
     }),
     ('PyVCF', '0.6.8', {
         'modulename': 'vcf',
-        'source_urls': ['https://files.pythonhosted.org/packages/source/p/PyVCF'],
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/PyVCF'],
         'checksums': ['e9d872513d179d229ab61da47a33f42726e9613784d1cb2bac3f8e2642f6f9d9'],
     }),
     ('xgboost', '0.90', {


### PR DESCRIPTION
* ```ngs-bits-2019_11-GCCcore-7.3.0```: First version including patch for Qt5.
* ```PythonPlus-3.7.4-foss-2018b-v20.02.1```: Bugfix in URL of Python package source code download.