### PR TITLE
CADD v1.4 easyconfig patch: support -c and -s

### DIFF
--- a/easybuild/easyconfigs/c/CADD/CADD-v1.4-foss-2018b.eb
+++ b/easybuild/easyconfigs/c/CADD/CADD-v1.4-foss-2018b.eb
@@ -90,7 +90,7 @@ checksums = [
     'ffa700e365803a9f38e2f119399ed22b',  # whole_genome_SNVs_inclAnno.tsv.gz
     '85eb138b68b8c89cdf89d5517df7b83d',  # gnomad.genomes.r2.0.1.sites.tsv.gz.tbi
     '78d5d0ecc81aed2abedf1bff6fa7d479',  # gnomad.genomes.r2.0.1.sites.tsv.gz
-    '96a5bbc074b44b7a872f6400b4b4d75c',  # CADD_v1.4.patch
+    '9e96988a0e091adfe311b38182e2e0a4',  # CADD_v1.4.patch
 ]
 
 #

--- a/easybuild/easyconfigs/c/CADD/CADD_v1.4.patch
+++ b/easybuild/easyconfigs/c/CADD/CADD_v1.4.patch
@@ -1,11 +1,11 @@
---- CADD.sh_bk	2018-12-03 17:00:24.000000000 +0100
-+++ CADD.sh	2019-02-15 17:53:18.754172855 +0100
-@@ -1,13 +1,16 @@
+--- CADD.sh_bk	2020-09-08 05:13:28.422731135 +0000
++++ CADD.sh	2020-09-08 05:47:57.549588194 +0000
+@@ -1,13 +1,18 @@
  #!/bin/bash
  
 -usage="$(basename "$0") [-o <outfile>] [-g <genomebuild>] [-a] <infile>  -- CADD version 1.4
 +# HEAD::Add -t help
-+usage="$(basename "$0") [-o <outfile>] [-g <genomebuild>] [-a] [-t <tmp-dir>] <infile>  -- CADD version 1.4
++usage="$(basename "$0") [-o <outfile>] [-g <genomebuild>] [-a] [-t <tmp-dir>] [-c <nr_cores>] [-s] <infile>  -- CADD version 1.4
  
  where:
      -h  show this help text
@@ -13,21 +13,26 @@
      -g  genome build (supported are GRCh37 and GRCh38 [default: GRCh38])
      -a  include annotation in output
 +    -t  temporary dir (please use a tmp-dir if /tmp not enough [default: /tmp])
++    -c  number of cpu cores [default: 1]
++    -s  skip prescoring
          input vcf of vcf.gz file (required)"
 +# TAIL::Add -t help
  
  unset OPTARG
  unset OPTIND
-@@ -15,7 +18,7 @@
+@@ -15,7 +20,10 @@
  GENOMEBUILD="GRCh38"
  ANNOTATION=false
  OUTFILE=""
 -while getopts ':ho:g:a' option; do
-+while getopts ':ho:g:at:' option; do
++CPU_CORES=1
++SKIP=false
++
++while getopts ':ho:g:at:c:s' option; do
    case "$option" in
      h) echo "$usage"
         exit
-@@ -26,6 +29,10 @@
+@@ -26,6 +34,14 @@
         ;;
      a) ANNOTATION=true
         ;;
@@ -35,10 +40,14 @@
 +    t) TMP_DIR=$OPTARG
 +       ;;
 +# TAIL::Add -t option
++    c) CPU_CORES=$OPTARG
++       ;;
++    s) SKIP=true
++       ;;
     \?) printf "illegal option: -%s\n" "$OPTARG" >&2
         echo "$usage" >&2
         exit 1
-@@ -82,7 +89,9 @@
+@@ -82,7 +98,9 @@
  CONVERSION_TABLE=$CADD/data/models/$GENOMEBUILD/conversionTable_CADD1.4-$GENOMEBUILD.txt
  
  # Temp files
@@ -49,7 +58,7 @@
  TMP_PRE=$TMP_FOLDER/$NAME.pre.tsv.gz
  TMP_VCF=$TMP_FOLDER/$NAME.vcf
  TMP_ANNO=$TMP_FOLDER/$NAME.anno.tsv.gz
-@@ -94,7 +103,10 @@
+@@ -94,7 +112,10 @@
  ### Pipeline
  
  # Loading the environment
@@ -61,7 +70,16 @@
  
  # File preparation
  if [ "$FILEFORMAT" == "vcf" ]
-@@ -127,6 +139,12 @@
+@@ -112,7 +133,7 @@
+ 
+ # Prescoring
+ echo '## Prescored variant file' | gzip -c > $TMP_PRE;
+-if [ -d $PRESCORED_FOLDER ]
++if [ -d $PRESCORED_FOLDER ] && [ "$SKIP" = 'false' ]
+ then
+     for PRESCORED in $(ls $PRESCORED_FOLDER/*.tsv.gz)
+     do
+@@ -127,6 +148,12 @@
  fi
  
  # Variant annotation
@@ -74,3 +92,12 @@
  cat $TMP_VCF \
  | vep --quiet --cache --buffer 1000 --no_stats --offline --vcf \
      --dir $CADD/data/annotations/$GENOMEBUILD/vep \
+@@ -134,7 +161,7 @@
+     --assembly $GENOMEBUILD --regulatory --sift b \
+     --polyphen b --per_gene --ccds --domains --numbers --canonical \
+     --total_length --force_overwrite --format vcf --output_file STDOUT \
+-    --warning_file STDERR \
++    --warning_file STDERR --fork ${CPU_CORES}\
+ | python $CADD/src/scripts/annotateVEPvcf.py -c $REFERENCE_CONFIG \
+ | gzip -c > $TMP_ANNO
+ rm $TMP_VCF


### PR DESCRIPTION
Add CADD v1.4 options:
- -c number of CPU cores
- -s skip precomputed scoring (significantly improves performance when you know that there will be no hits, e.g. CAPICE use case)