### PR TITLE
CADD v1.4-minimal easyconfig

### DIFF
--- a/easybuild/easyconfigs/c/CADD/CADD-v1.4-foss-2018b-minimal.eb
+++ b/easybuild/easyconfigs/c/CADD/CADD-v1.4-foss-2018b-minimal.eb
@@ -1,0 +1,118 @@
+#
+# EasyConfig for Combined Annotation Dependent Depletion (CADD).
+#
+
+easyblock = 'Tarball'
+
+name = 'CADD'
+version = 'v1.4'
+versionsuffix = '-minimal'
+
+homepage = 'http://cadd.gs.washington.edu/home'
+description = """
+Tool for scoring the deleteriousness of variants in the human genome(v1.4). Without prescored files.
+"""
+
+#
+# Don't use 'dummy' as toolchain version to make sure dependencies are loaded
+# both at build as well as at runtime. With 'dummy' as toolchain version,
+# dependencies will only be loaded at runtime.
+#
+#toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+dependencies = [
+    ('PythonPlus', '2.7.16', '-v20.02.1', ('foss', '2018b')),
+    ('HTSlib', '1.9', '', ('foss', '2018b')),
+    ('SAMtools', '1.9', '', ('foss', '2018b')),
+    ('VEP', '92.0', '-Perl-5.30.0', ('foss', '2018b')),
+]
+
+#
+# Example URL: 
+# http://krishna.gs.washington.edu/download/%(name)s/%(version)s/
+#
+source_urls = [ 
+    # Only for annotations which is built on genome build GRCh37/hg19
+    'https://krishna.gs.washington.edu/download/%(name)s/%(version)s/GRCh37/',
+    'https://github.com/kircherlab/%(name)s-scripts/archive/',
+]
+
+sources = [
+    #
+    # Use arbitrary 232fc0bda9f9ed127694f1d38669db043918328e.zip from github.
+    #
+    {
+        'filename': '232fc0bda9f9ed127694f1d38669db043918328e.zip',  
+        'extract_cmd': 'unzip %s -d %(builddir)s/'
+    },
+    {
+        'filename': 'annotationsGRCh37.tar.gz',
+        'extract_cmd': 'cp %s %(builddir)s/'
+    }
+]
+
+patches = ['CADD_v1.4.patch']
+
+checksums = [
+    '00b6eaf6b861c7771decc8abcb18dd55',  # 232fc0bda9f9ed127694f1d38669db043918328e.zip
+    '66afec8cc12b7201daed3ba4172cde5d',  # annotationsGRCh37.tar.gz
+    '9e96988a0e091adfe311b38182e2e0a4',  # CADD_v1.4.patch
+]
+
+#
+# Customizations for the install step.
+#
+bash_scripts = ['CADD.sh', 'install.sh']
+python_scripts = [
+    'annotateVEPvcf.py', 'appendPHREDscore.py', 'extract_scored.py', 
+    'max_line_hierarchy.py', 'predictSKmodel.py', 'trackTransformation.py', 
+    'VCF2vepVCF.py', 'lib/AnalysisLib.py', 'lib/Annotations.py', 
+    'lib/columnInfo.py', 'lib/EDict.py', 'lib/tracks.py',
+]
+not_scripts = ['README.md', 'LICENSE', 'src/environment.yml']
+
+#
+# Make scripts executable and move prescored variants to prescored subdir.
+#
+postinstallcmds = [
+    #
+    # Post processes on scripts
+    # Decompress the scripts, rename the scripts directory to bin, remove zip 
+    # file and alter the permission of `install.sh` and `CADD.sh.orig`
+    #
+    'chmod 755 %(installdir)s/*.sh %(installdir)s/src/scripts/*.py',
+    'chmod 400 %(installdir)s/install.sh %(installdir)s/CADD.sh.orig',
+
+    #
+    # Annotation files based on genome build GRCh37
+    # Decompress the annotations file, decompress the annotation on genome 
+    # build GRCh37/h19 and remove the `tar.gz` file
+    #
+    'tar -vzxf %(builddir)s/annotationsGRCh37.tar.gz '
+        + ' -C %(installdir)s/data/annotations',
+    'rm -f %(builddir)s/annotationsGRCh37.tar.gz',
+]
+
+sanity_check_paths = {
+    'files': ['%s' % x for x in bash_scripts]
+             + ['src/scripts/%s' % x for x in python_scripts]
+             + ['%s' % x for x in not_scripts],
+    'dirs': ['%s' % x for x in ['config', 'data', 'src', 'test']],
+}
+
+moduleclass = 'bio'
+modextrapaths = {'PATH': ''}
+modloadmsg = """
+
+===============================================================================
+USAGE: CADD.sh [-o <outfile>] [-g <genomebuild>] [-a] <infile>
+
+E.g: 
+    CADD.sh input.vcf
+    CADD.sh -a -g GRCh37 -o output_inclAnno_GRCh37.tvs.gz input.vcf
+
+NOTE: input must be a valid bgzipped (not gzipped) VCF file.
+===============================================================================
+
+"""


### PR DESCRIPTION
CADD v1.4 easyconfig without 214GB of precomputed score files. Useful in case:
- disk space is a scarce resource
- performance is less important
- CADD is only used through CAPICE