### PR TITLE
Add Genmod lib to PythonPlus 3.7.4 and update nbformat lib

### DIFF
--- a/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.11.1.eb
+++ b/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.11.1.eb
@@ -1,0 +1,792 @@
+easyblock = 'Bundle'
+
+name = 'PythonPlus'
+version = '3.7.4'             # Same as the vanilla Python module on which these add-on modules depend.
+versionsuffix = '-v20.11.1'   # In format YY.MM.IncrementedReleaseNumber.
+
+homepage = 'https://www.python.org/'
+description = """The PythonPlus bundle contains a plain vanilla Python supplemented with a selection of add-on modules."""
+
+#
+# numpy requires BLAS -> use full foss toolchain as opposed to GCCcore.
+# scipy requires compiler option -fPIC.
+#
+toolchain = {'name': 'foss', 'version': '2018b'}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('Python', version, '-bare'),
+    ('LZO', '2.10'),
+    ('libxml2', '2.9.8'),
+    ('libxslt', '1.1.33'),
+    ('libpng', '1.6.37'),
+    ('cairo', '1.16.0'),
+    ('ICU', '64.2'),
+]
+
+#
+# This is a bundle of extra Python packages to be used with a "bare" Python installation.
+#
+exts_defaultclass = 'PythonPackage'
+exts_filter = ('python -c "import %(ext_name)s"', "")
+
+exts_list = [
+     ('simplegeneric', '0.8.1', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/simplegeneric'],
+        'checksums': ['dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173'],
+    }),
+    ('python-lzo', '1.12', {
+        'modulename': 'lzo',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/python-lzo'],
+        'checksums': ['97a8e46825e8f1abd84c2a3372bc09adae9745a5be5d3af2692cd850dac35345'],
+    }),
+    ('six', '1.12.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/six'],
+        'checksums': ['d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73'],
+    }),
+    ('setuptools', '41.1.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/setuptools'],
+        'checksums': ['c519b84c299911fd94ef47e3de4fe678c254aefc5cdf8a9b12e4cdc8cc3744a8'],
+    }),
+    ('numpy', '1.17.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/numpy'],
+        'checksums': ['951fefe2fb73f84c620bec4e001e80a80ddaa1b84dce244ded7f1e0cbe0ed34a'],
+    }),
+    ('bx-python', '0.8.4', {
+        'modulename': 'bx',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/bx-python'],
+        'checksums': ['9698390a777a41d3b7f5e833ec1bacb8193fea847889a2092c848afd6b8a7b85'],
+    }),
+    ('patsy', '0.5.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/patsy'],
+        'checksums': ['f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991'],
+    }),
+    ('scipy', '1.3.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/scipy'],
+        'checksums': ['2643cfb46d97b7797d1dbdb6f3c23fe3402904e3c90e6facfe6a9b98d808c1b5'],
+    }),
+    ('pandas', '0.25.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pandas'],
+        'checksums': ['914341ad2d5b1ea522798efa4016430b66107d05781dbfe7cf05eba8f37df995'],
+    }),
+    ('statsmodels', '0.10.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/statsmodels'],
+        'checksums': ['320659a80f916c2edf9dfbe83512d9004bb562b72eedb7d9374562038697fa10'],
+    }),
+    ('joblib', '0.13.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/j/joblib'],
+        'checksums': ['315d6b19643ec4afd4c41c671f9f2d65ea9d787da093487a81ead7b0bac94524'],
+    }),
+    ('Cython', '0.29.13', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/C/Cython'],
+        'checksums': ['c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e'],
+    }),
+    ('scikit-learn', '0.21.3', {
+        'modulename': 'sklearn',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/scikit-learn'],
+        'checksums': ['eb9b8ebf59eddd8b96366428238ab27d05a19e89c5516ce294abc35cea75d003'],
+    }),
+    ('py', '1.8.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/py'],
+        'checksums': ['dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53'],
+    }),
+    ('attrs', '19.1.0', {
+        'modulename': 'attr',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/attrs'],
+        'checksums': ['f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399'],
+    }),
+    ('pyparsing', '2.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyparsing'],
+        'checksums': ['6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80'],
+    }),
+    ('packaging', '19.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/packaging'],
+        'checksums': ['c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe'],
+    }),
+    ('more-itertools', '7.2.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/more-itertools'],
+        'checksums': ['409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832'],
+    }),
+    ('atomicwrites', '1.3.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/atomicwrites'],
+        'checksums': ['75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6'],
+    }),
+    ('scandir', '1.10.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/scandir'],
+        'checksums': ['4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae'],
+    }),
+    ('pathlib2', '2.3.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pathlib2'],
+        'checksums': ['446014523bb9be5c28128c4d2a10ad6bb60769e78bd85658fe44a450674e0ef8'],
+    }),
+    ('contextlib2', '0.5.5', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/contextlib2'],
+        'checksums': ['509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48'],
+    }),
+    ('unittest2', '1.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/u/unittest2'],
+        'checksums': ['22882a0e418c284e1f718a822b3b022944d53d2d908e1690b319a9d3eb2c0579'],
+    }),
+    ('zipp', '0.5.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/z/zipp'],
+        'checksums': ['4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a'],
+    }),
+    ('docutils', '0.15.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/docutils'],
+        'checksums': ['a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99'],
+    }),
+    ('entrypoints', '0.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/e/entrypoints'],
+        'checksums': ['c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451'],
+    }),
+    ('pyflakes', '2.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyflakes'],
+        'checksums': ['d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2'],
+    }),
+    ('pycodestyle', '2.5.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pycodestyle'],
+        'checksums': ['e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c'],
+    }),
+    ('mccabe', '0.6.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mccabe'],
+        'checksums': ['dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f'],
+    }),
+    ('flake8', '3.7.8', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/flake8'],
+        'checksums': ['19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548'],
+    }),
+    ('pytest-flake8', '1.0.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-flake8'],
+        'checksums': ['4d225c13e787471502ff94409dcf6f7927049b2ec251c63b764a4b17447b60c0'],
+    }),
+    ('pytest-checkdocs', '1.2.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-checkdocs'],
+        'checksums': ['0867adc08cb64662fca9468ac5df23fa52be3364fdbe350bbcd270261b3b821d'],
+    }),
+    ('configparser', '3.8.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/configparser'],
+        'checksums': ['bc37850f0cc42a1725a796ef7d92690651bf1af37d744cc63161dac62cabee17'],
+    }),
+    ('importlib_resources', '1.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/importlib_resources'],
+        'checksums': ['d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078'],
+    }),
+    ('importlib_metadata', '0.19', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/importlib_metadata'],
+        'checksums': ['23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8'],
+    }),
+    ('pluggy', '0.12.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pluggy'],
+        'checksums': ['0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc'],
+    }),
+    ('wcwidth', '0.1.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/wcwidth'],
+        'checksums': ['3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e'],
+    }),
+    ('colorama', '0.4.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/colorama'],
+        'checksums': ['05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d'],
+    }),
+    ('coverage', '4.5.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/coverage'],
+        'checksums': ['e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c'],
+    }),
+    ('ptyprocess', '0.6.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/ptyprocess'],
+        'checksums': ['923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0'],
+    }),
+    ('pexpect', '4.7.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pexpect'],
+        'checksums': ['9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb'],
+    }),
+    ('fields', '5.0.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/fields'],
+        'checksums': ['31d4aa03d8d44e35df13c431de35136997f047a924a597d84f7bc209e1be5727'],
+    }),
+    ('manhole', '1.6.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/manhole'],
+        'checksums': ['d4ab98198481ed54a5b95c0439f41131f56d7d3755eedaedce5a45ca7ff4aa42'],
+    }),
+    ('hunter', '3.0.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/h/hunter'],
+        'checksums': ['26c41a971e92f1ba9d6772081203e3478258fc45f8162b3ead031ca04ba2adfe'],
+    }),
+    ('process-tests', '2.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/process-tests'],
+        'checksums': ['7ae24a680cc7c44e7687e3723e6e64597a28223ad664989999efe10dd38c2431'],
+    }),
+    ('pytest-cov', '2.7.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-cov'],
+        'checksums': ['e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a'],
+    }),
+    ('wheel', '0.33.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/wheel'],
+        'checksums': ['62fcfa03d45b5b722539ccbc07b190e4bfff4bb9e3a4d470dd9f6a0981002565'],
+    }),
+    ('argcomplete', '1.10.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/argcomplete'],
+        'checksums': ['45836de8cc63d2f6e06b898cef1e4ce1e9907d246ec77ac8e64f23f153d6bec1'],
+    }),
+    ('pytz', '2019.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytz'],
+        'checksums': ['26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32'],
+    }),
+    ('sqlparse', '0.3.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sqlparse'],
+        'checksums': ['7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873'],
+    }),
+    ('argon2_cffi', '19.1.0', {
+        'modulename': 'argon2',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/argon2-cffi'],
+        'checksums': ['81548a27b919861040cb928a350733f4f9455dd67c7d1ba92eb5960a1d7f8b26'],
+    }),
+    ('bcrypt', '3.1.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/bcrypt'],
+        'checksums': ['0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42'],
+    }),
+    ('Django', '2.2.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/D/Django'],
+        'checksums': ['16a5d54411599780ac9dfe3b9b38f90f785c51259a584e0b24b6f14a7f69aae8'],
+    }),
+    ('dpcontracts', '0.6.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/dpcontracts'],
+        'checksums': ['6cf9df1f16beaa48523b798b41170dabf7a536a6133328731665cdb29c42234a'],
+    }),
+    ('lark-parser', '0.7.3', {
+        'modulename': 'lark',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/l/lark-parser'],
+        'checksums': ['e60a85bf0ecdd938be81f3c2f033f4becf69a221ccbbbc34d68b4dfd853f6d0e'],
+    }),
+    ('python-dateutil', '2.8.0', {
+        'modulename': 'dateutil',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/python-dateutil'],
+        'checksums': ['c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e'],
+    }),
+    ('apipkg', '1.5', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/apipkg'],
+        'checksums': ['37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6'],
+    }),
+    ('execnet', '1.7.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/e/execnet'],
+        'checksums': ['3839f3c1e9270926e7b3d9b0a52a57be89c302a3826a2b19c8d6e6c3d2b506d2'],
+    }),
+    ('pytest-forked', '1.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-forked'],
+        'checksums': ['d352aaced2ebd54d42a65825722cb433004b4446ab5d2044851d9cc7a00c9e38'],
+    }),
+    ('filelock', '3.0.12', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/filelock'],
+        'checksums': ['18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59'],
+    }),
+    ('pytest-xdist', '1.29.0', {
+        'modulename': 'xdist',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-xdist'],
+        'checksums': ['3489d91516d7847db5eaecff7a2e623dba68984835dbe6cedb05ae126c4fb17f'],
+    }),
+    ('hypothesis', '4.32.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/h/hypothesis'],
+        'checksums': ['c6d4ba47bc97e4651fccd692d6cecca9c1ad673f114107e4d37419d5fc172ee2'],
+    }),
+    ('funcsigs', '1.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/funcsigs'],
+        'checksums': ['a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/nose'],
+        'checksums': ['f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98'],
+    }),
+    ('pkginfo', '1.5.0.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pkginfo'],
+        'checksums': ['7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb'],
+    }),
+    ('webencodings', '0.5.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/webencodings'],
+        'checksums': ['b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923'],
+    }),
+    ('bleach', '3.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/bleach'],
+        'checksums': ['3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa'],
+    }),
+    ('Pygments', '2.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/Pygments'],
+        'checksums': ['881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297'],
+    }),
+    ('cmarkgfm', '0.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/cmarkgfm'],
+        'checksums': ['f20900f16377f2109783ae9348d34bc80530808439591c3d3df73d5c7ef1a00c'],
+    }),
+    ('readme_renderer', '24.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/r/readme_renderer'],
+        'checksums': ['bb16f55b259f27f75f640acf5e00cf897845a8b3e4731b5c1a436e4b8529202f'],
+    }),
+    ('chardet', '3.0.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/chardet'],
+        'checksums': ['84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae'],
+    }),
+    ('idna', '2.8', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/idna'],
+        'checksums': ['c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407'],
+    }),
+    ('brotlipy', '0.7.0', {
+        'modulename': 'brotli',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/brotlipy'],
+        'checksums': ['36def0b859beaf21910157b4c33eb3b06d8ce459c942102f16988cca6ea164df'],
+    }),
+    ('cryptography', '2.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/cryptography'],
+        'checksums': ['e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6'],
+    }),
+    ('flaky', '3.6.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/flaky'],
+        'checksums': ['8cd5455bb00c677f787da424eaf8c4a58a922d0e97126d3085db5b279a98b698'],
+    }),
+    ('pretend', '1.0.9', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pretend'],
+        'checksums': ['c90eb810cde8ebb06dafcb8796f9a95228ce796531bc806e794c2f4649aa1b10'],
+    }),
+    ('pyOpenSSL', '19.0.0', {
+        'modulename': 'OpenSSL',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyOpenSSL'],
+        'checksums': ['aeca66338f6de19d1aa46ed634c3b9ae519a64b458f8468aec688e7e3c20f200'],
+    }),
+    ('certifi', '2019.6.16', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/certifi'],
+        'checksums': ['945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695'],
+    }),
+    ('ipaddress', '1.0.22', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/ipaddress'],
+        'checksums': ['b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c'],
+    }),
+    ('PySocks', '1.7.0', {
+        'modulename': 'socks',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/PySocks'],
+        'checksums': ['d9031ea45fdfacbe59a99273e9f0448ddb33c1580fe3831c1b09557c5718977c'],
+    }),
+    ('urllib3', '1.25.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/u/urllib3'],
+        'checksums': ['dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232'],
+    }),
+    ('requests', '2.22.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/r/requests'],
+        'checksums': ['11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4'],
+    }),
+    ('requests-toolbelt', '0.9.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/r/requests-toolbelt'],
+        'checksums': ['968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0'],
+    }),
+    ('tqdm', '4.33.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/tqdm'],
+        'checksums': ['1dc82f87a8726602fa7177a091b5e8691d6523138a8f7acd08e58088f51e389f'],
+    }),
+    ('testpath', '0.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/testpath'],
+        'checksums': ['b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8'],
+    }),
+    ('jeepney', '0.4.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/j/jeepney'],
+        'checksums': ['13806f91a96e9b2623fd2a81b950d763ee471454aafd9eb6d75dbe7afce428fb'],
+    }),
+    ('SecretStorage', '3.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/S/SecretStorage'],
+        'checksums': ['20c797ae48a4419f66f8d28fc221623f11fc45b6828f96bdb1ad9990acb59f92'],
+    }),
+    ('pytest-black', '0.3.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-black'],
+        'checksums': ['75bbeccfe23442a190164c0bf202d7498df25451fa4177b781cee20183e7fc0d'],
+    }),
+    ('pytest-black-multipy', '1.0.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-black-multipy'],
+        'checksums': ['cd6bf8d9e60af4d97771f848d5efae8eef30c9c77d4bb6f57a767ceb52523cb2'],
+    }),
+    ('keyring', '19.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/k/keyring'],
+        'checksums': ['1b74595f7439e4581a11d4f9a12790ac34addce64ca389c86272ff465f5e0b90'],
+    }),
+    ('pyblake2', '1.1.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyblake2'],
+        'checksums': ['5ccc7eb02edb82fafb8adbb90746af71460fbc29aa0f822526fc976dff83e93f'],
+    }),
+    ('twine', '1.13.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/twine'],
+        'checksums': ['d6c29c933ecfc74e9b1d9fa13aa1f87c5d5770e119f5a4ce032092f0ff5b14dc'],
+    }),
+    ('blurb', '1.0.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/blurb'],
+        'checksums': ['1849eb2c9ceb74928d24eab847d344a8602e8ee822aeba2e930c4e6c7543e9e4'],
+    }),
+    ('mock', '3.0.5', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mock'],
+        'checksums': ['83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3'],
+    }),
+    ('pytest', '5.0.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest'],
+        'checksums': ['6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d'],
+    }),
+    ('pytest-timeout', '1.3.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-timeout'],
+        'checksums': ['4a30ba76837a32c7b7cd5c84ee9933fde4b9022b0cd20ea7d4a577c2a1649fb1'],
+    }),
+    ('pytest-localserver', '0.5.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytest-localserver'],
+        'checksums': ['3a5427909d1dfda10772c1bae4b9803679c0a8f04adb66c338ac607773bfefc2'],
+    }),
+    ('watchdog', '0.9.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/watchdog'],
+        'checksums': ['965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d'],
+    }),
+    ('passlib', '1.7.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/passlib'],
+        'checksums': ['3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0'],
+    }),
+    ('pypiserver', '1.3.0', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pypiserver'],
+        'checksums': ['c0361290ee11eb267475761adc1e663ef0a56739a323cfefdf904e46f693ce0a'],
+    }),
+    ('xonsh', '0.9.10', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/x/xonsh'],
+        'checksums': ['3c2d23b16eee7f8ad2ce6d02e5f81e1627ebd722b709d0788ceb5b2a9ee76822'],
+    }),
+    ('virtualenv', '16.7.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/v/virtualenv'],
+        'checksums': ['909fe0d3f7c9151b2df0a2cb53e55bdb7b0d61469353ff7a49fd47b0f0ab9285'],
+    }),
+    ('fastnumbers', '2.2.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/fastnumbers'],
+        'checksums': ['5eef2565d9202bf32263f2f100287e97c4dc6fa28a07fb273431db7349892548'],
+    }),
+    ('PyICU', '2.3.1', {
+        'modulename': 'icu',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/PyICU'],
+        'checksums': ['ddb2b453853b4c25db382bc5e8c4cde09b3f4696ef1e1494f8294e174f459cf4'],
+    }),
+    ('natsort', '6.0.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/natsort'],
+        'checksums': ['ff3effb5618232866de8d26e5af4081a4daa9bb0dfed49ac65170e28e45f2776'],
+    }),
+    ('matplotlib', '3.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/matplotlib'],
+        'checksums': ['1febd22afe1489b13c6749ea059d392c03261b2950d1d45c17e3aed812080c93'],
+    }),
+    ('ipython_genutils', '0.2.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/ipython_genutils'],
+        'checksums': ['eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8'],
+    }),
+    ('decorator', '4.4.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/decorator'],
+        'checksums': ['86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de'],
+    }),
+    ('traitlets', '4.3.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/traitlets'],
+        'checksums': ['9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835'],
+    }),
+    ('prompt_toolkit', '2.0.9', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/prompt_toolkit'],
+        'checksums': ['2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1'],
+    }),
+    ('pickleshare', '0.7.5', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pickleshare'],
+        'checksums': ['87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca'],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/docopt'],
+        'checksums': ['49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491'],
+    }),
+    ('parso', '0.5.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/parso'],
+        'checksums': ['666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c'],
+    }),
+    ('jedi', '0.15.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/j/jedi'],
+        'checksums': ['ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e'],
+    }),
+    ('backcall', '0.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/backcall'],
+        'checksums': ['38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4'],
+    }),
+    ('MarkupSafe', '1.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/M/MarkupSafe'],
+        'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],
+    }),
+    ('Babel', '2.7.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/B/Babel'],
+        'checksums': ['e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28'],
+    }),
+    ('Jinja2', '2.10.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/J/Jinja2'],
+        'checksums': ['065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013'],
+    }),
+    ('tornado', '6.0.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/tornado'],
+        'checksums': ['c845db36ba616912074c5b1ee897f8e0124df269468f25e4fe21fe72f6edd7a9'],
+    }),
+    ('pyzmq', '18.1.0', {
+        'modulename': 'zmq',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyzmq'],
+        'checksums': ['93f44739db69234c013a16990e43db1aa0af3cf5a4b8b377d028ff24515fbeb3'],
+    }),
+    ('pyrsistent', '0.15.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pyrsistent'],
+        'checksums': ['34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533'],
+    }),
+    ('jsonpointer', '2.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/j/jsonpointer'],
+        'checksums': ['c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362'],
+    }),
+    ('rfc3987', '1.3.8', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/r/rfc3987'],
+        'checksums': ['d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733'],
+    }),
+    ('strict-rfc3339', '0.7', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/strict-rfc3339'],
+        'checksums': ['5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277'],
+    }),
+    ('webcolors', '1.9.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/webcolors'],
+        'checksums': ['18c091bd4bd75efd1e9f84f5eca4a54f6e6485eaa3967d2a55700835a1b1c418'],
+    }),
+    ('jsonschema', '3.0.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/j/jsonschema'],
+        'checksums': ['8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d'],
+    }),
+    ('nbformat', '5.0.8', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/nbformat'],
+        'checksums': ['f545b22138865bfbcc6b1ffe89ed5a2b8e2dc5d4fe876f2ca60d8e6f702a30f8'],
+    }),
+    ('mistune', '0.8.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mistune'],
+        'checksums': ['59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e'],
+    }),
+    ('pandocfilters', '1.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pandocfilters'],
+        'checksums': ['b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9'],
+    }),
+    ('defusedxml', '0.6.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/defusedxml'],
+        'checksums': ['f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5'],
+    }),
+    ('widgetsnbextension', '3.5.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/w/widgetsnbextension'],
+        'checksums': ['079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7'],
+    }),
+    ('ipywidgets', '7.5.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/ipywidgets'],
+        'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
+    }),
+    ('Pebble', '4.3.10', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/Pebble'],
+        'checksums': ['c39a7bf99af6525fcf0783a8859fb10a4f20f4f988ddb66fd6fa7588f9c91731'],
+    }),
+    ('typed_ast', '1.4.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/typed_ast'],
+        'checksums': ['66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34'],
+    }),
+    ('mypy_extensions', '0.4.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mypy_extensions'],
+        'checksums': ['37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812'],
+    }),
+    ('psutil', '5.6.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/psutil'],
+        'checksums': ['863a85c1c0a5103a12c05a35e59d336e1d665747e531256e061213e2e90f63f3'],
+    }),
+    ('mypy', '0.720', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mypy'],
+        'checksums': ['49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4'],
+    }),
+    ('sphinxcontrib-devhelp', '1.0.1', {
+        'modulename': 'sphinxcontrib.devhelp',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib-devhelp'],
+        'checksums': ['6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34'],
+    }),
+    ('sphinxcontrib-jsmath', '1.0.1', {
+        'modulename': 'sphinxcontrib.jsmath',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib-jsmath'],
+        'checksums': ['a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8'],
+    }),
+    ('Genshi', '0.7.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/G/Genshi'],
+        'checksums': ['7933c95151d7dd2124a2b4c8dd85bb6aec881ca17c0556da0b40e56434b313a0'],
+    }),
+    ('datrie', '0.8', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/datrie'],
+        'checksums': ['bdd5da6ba6a97e7cd96eef2e7441c8d2ef890d04ba42694a41c7dffa3aca680c'],
+    }),
+    ('cssselect', '1.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/cssselect'],
+        'checksums': ['f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc'],
+    }),
+    ('collective.checkdocs', '0.2', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/collective.checkdocs'],
+        'checksums': ['3a5328257c5224bc72753820c182910d7fb336bc1dba5e09113d48566655e46e'],
+    }),
+    ('soupsieve', '1.9.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/soupsieve'],
+        'checksums': ['72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946'],
+    }),
+    ('beautifulsoup4', '4.8.0', {
+        'modulename': 'bs4',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/beautifulsoup4'],
+        'checksums': ['25288c9e176f354bf277c0a10aa96c782a6a18a17122dba2e8cec4a97e03343b'],
+    }),
+    ('lxml', '4.4.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/l/lxml'],
+        'checksums': ['c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692'],
+    }),
+    ('html5lib', '1.0.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/h/html5lib'],
+        'checksums': ['66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736'],
+    }),
+    ('sphinxcontrib-htmlhelp', '1.0.2', {
+        'modulename': 'sphinxcontrib.htmlhelp',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib-htmlhelp'],
+        'checksums': ['4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422'],
+    }),
+    ('sphinxcontrib-serializinghtml', '1.1.3', {
+        'modulename': 'sphinxcontrib.serializinghtml',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib-serializinghtml'],
+        'checksums': ['c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227'],
+    }),
+    ('sphinxcontrib-qthelp', '1.0.2', {
+        'modulename': 'sphinxcontrib.qthelp',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib-qthelp'],
+        'checksums': ['79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f'],
+    }),
+    ('snowballstemmer', '1.9.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/snowballstemmer'],
+        'checksums': ['9f3b9ffe0809d174f7047e121431acf99c89a7040f0ca84f94ba53a498e6d0c9'],
+    }),
+    ('alabaster', '0.7.12', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/a/alabaster'],
+        'checksums': ['a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02'],
+    }),
+    ('imagesize', '1.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/imagesize'],
+        'checksums': ['f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5'],
+    }),
+    ('flake8-import-order', '0.18.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/f/flake8-import-order'],
+        'checksums': ['a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92'],
+    }),
+    ('docutils-stubs', '0.0.21', {
+        'modulename': 'docutils.core', # technically not correct, but only used here to satisfy the sanity check step.
+        'source_urls': ['https://files.pythonhosted.org/packages/source/d/docutils-stubs'],
+        'checksums': ['e0d3d2588a0c0b47bf66b917bf4ff2c100cf4cf77bbe2f518d97b8f4d63e735c'],
+    }),
+    ('Sphinx', '2.1.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/S/Sphinx'],
+        'checksums': ['f9a79e746b87921cabc3baa375199c6076d1270cee53915dbd24fdbeaaacc427'],
+    }),
+    ('sphinx_rtd_theme', '0.4.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme'],
+        'checksums': ['728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a'],
+    }),
+    ('nbsphinx', '0.4.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/nbsphinx'],
+        'checksums': ['b794219e465b3aab500b800884ff40fd152bb19d8b6f87580de1f3a07170aef8'],
+    }),
+    ('sphinxcontrib_github_alt', '1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/sphinxcontrib_github_alt'],
+        'checksums': ['50e8493c1362c9203179ab46c2265554d027f22ba71650283a517f76781a9a87'],
+    }),
+    ('Send2Trash', '1.5.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/S/Send2Trash'],
+        'checksums': ['60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2'],
+    }),
+    ('terminado', '0.8.2', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/t/terminado'],
+        'checksums': ['de08e141f83c3a0798b050ecb097ab6259c3f0331b2f7b7750c9075ced2c20c2'],
+    }),
+    ('prometheus_client', '0.7.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/prometheus_client'],
+        'checksums': ['71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da'],
+    }),
+    ('nose_warnings_filters', '0.1.5', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/nose_warnings_filters'],
+        'checksums': ['456c5b2ccca24e1d00a7b558274ebf9318305813dcb9585951a73ae11d76bb9d'],
+    }),
+    ('nose-exclude', '0.5.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/n/nose-exclude'],
+        'checksums': ['f78fa8b41eeb815f0486414f710f1eea0949e346cfb11d59ba6295ed69e84304'],
+    }),
+    ('selenium', '3.141.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/selenium'],
+        'checksums': ['deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d'],
+    }),
+    ('ipython', '7.7.0', {
+        'modulename': 'IPython',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/i/ipython'],
+        'checksums': ['1d3a1692921e932751bc1a1f7bb96dc38671eeefdc66ed33ee4cbc57e92a410e'],
+    }),
+    ('scikit-bio', '0.5.5', {
+        'modulename': 'skbio',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/scikit-bio'],
+        'checksums': ['9fa813be66e88a994f7b7a68b8ba2216e205c525caa8585386ebdeebed6428df'],
+    }),
+    ('biopython', '1.74', {
+        'modulename': 'Bio',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/biopython'],
+        'checksums': ['25152c1be2c9205bf80901fc49adf2c2efff49f0dddbcf6e6b2ce31dfa6590c0'],
+    }),
+    ('ete3', '3.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/e/ete3'],
+        'checksums': ['870a3d4b496a36fbda4b13c7c6b9dfa7638384539ae93551ec7acb377fb9c385'],
+    }),
+    ('click', '7.0', {
+        'source_tmpl': 'Click-%(version)s.tar.gz',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/click'],
+        'checksums': ['5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7'],
+    }),
+    ('livereload', '2.6.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/l/livereload'],
+        'checksums': ['89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66'],
+    }),
+    ('PyYAML', '5.1.2', {
+        'modulename': 'yaml',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/PyYAML'],
+        'checksums': ['01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4'],
+    }),
+    ('Markdown', '3.1.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/M/Markdown'],
+        'checksums': ['2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a'],
+    }),
+    ('mkdocs', '1.0.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/m/mkdocs'],
+        'checksums': ['17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939'],
+    }),
+
+    ('pysam', '0.15.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/p/pysam'],
+        'checksums': ['a535e15cbd6e27f4ab74cabca30ca1df7eea283cb91d3b536d47fe113fee066f'],
+    }),
+    ('PyVCF', '0.6.8', {
+        'modulename': 'vcf',
+        'source_urls': ['https://files.pythonhosted.org/packages/source/P/PyVCF'],
+        'checksums': ['e9d872513d179d229ab61da47a33f42726e9613784d1cb2bac3f8e2642f6f9d9'],
+    }),
+    ('xgboost', '0.90', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/x/xgboost'],
+        'checksums': ['d69f90d61a63e8889fd39a31ad00c629bac1ca627f8406b9b6d4594c9e29ab84'],
+    }),
+    ('genmod', '3.7.3', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/g/genmod'],
+        'checksums': ['f4627405763b9c8a3e8072adfee185303f56c866b2ee19d54b7279a4a948aded'],
+    }),	
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+#
+# Run a full sanity check as opposed to just trying to load the Python package.
+#
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs':  ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.11.1.eb
+++ b/easybuild/easyconfigs/p/PythonPlus/PythonPlus-3.7.4-foss-2018b-v20.11.1.eb
@@ -757,7 +757,6 @@ exts_list = [
         'source_urls': ['https://files.pythonhosted.org/packages/source/m/mkdocs'],
         'checksums': ['17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939'],
     }),
-
     ('pysam', '0.15.4', {
         'source_urls': ['https://files.pythonhosted.org/packages/source/p/pysam'],
         'checksums': ['a535e15cbd6e27f4ab74cabca30ca1df7eea283cb91d3b536d47fe113fee066f'],


### PR DESCRIPTION
Added genmod 3.0.7 module to PythonPlus.
http://moonso.github.io/genmod/
https://pypi.org/project/genmod/

Installation of the easybuild failed on "nbformat", even before trying to install the genmod lib, on a version conflict issue, this is fixed by updating the "nbformat" to version 5.0.8 (was 4.4.0)