### PR TITLE
Bugfixes for CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb

### DIFF
--- a/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
@@ -47,6 +47,10 @@ exts_list = [
         'source_urls': ['https://files.pythonhosted.org/packages/source/s/setuptools'],
         'checksums': ['c519b84c299911fd94ef47e3de4fe678c254aefc5cdf8a9b12e4cdc8cc3744a8'],
     }),
+    ('six', '1.12.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/six'],
+        'checksums': ['d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73'],
+    }),
     ('python-dateutil', '2.8.0', {
         'modulename': 'dateutil',
         'source_urls': ['https://files.pythonhosted.org/packages/source/p/python-dateutil'],
@@ -59,10 +63,6 @@ exts_list = [
     ('pytz', '2019.2', {
         'source_urls': ['https://files.pythonhosted.org/packages/source/p/pytz'],
         'checksums': ['26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32'],
-    }),
-    ('six', '1.12.0', {
-        'source_urls': ['https://files.pythonhosted.org/packages/source/s/six'],
-        'checksums': ['d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73'],
     }),
     ('functools32', '3.2.3-2', {
         'source_urls': ['https://files.pythonhosted.org/packages/source/f/functools32'],
@@ -89,6 +89,22 @@ exts_list = [
             '2bda3b1ffbe20ee35d5337d97071ff4177a7742b15e7837324ae7c5720e82678', # source
             '49dfe6b95d2f6807c296bd7f0408a81b7afdaf03716488b389086b1a3cc32d1d', # patch
         ],
+    }),
+    ('subprocess32', '3.5.4', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/s/subprocess32'],
+        'checksums': ['eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d'],
+    }),
+    ('backports.functools_lru_cache', '1.6.1', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/b/backports.functools_lru_cache'],
+        'checksums': ['8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a'],
+    }),
+    ('kiwisolver', '1.1.0', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/k/kiwisolver'],
+        'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
+    }),
+    ('cycler-0.10.0', '', {
+        'source_urls': ['https://files.pythonhosted.org/packages/source/c/cycler'],
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),
     ('matplotlib', '2.2.4', {
         'source_urls': ['https://files.pythonhosted.org/packages/source/m/matplotlib'],

--- a/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('Python', '2.7.16', '-bare'),
     ('libpng', '1.6.37'),
     ('freetype', '2.10.1'),
-    ('HDF5', '1.10.6'),
+    ('HDF5', '1.8.21'),
     ('LZO', '2.10'),
     ('libxml2', '2.9.8'),
     ('libxslt', '1.1.33'),

--- a/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/c/CoNIFERPyDepBundle/CoNIFERPyDepBundle-0.2.2-foss-2018b-Python-2.7.16.eb
@@ -102,7 +102,7 @@ exts_list = [
         'source_urls': ['https://files.pythonhosted.org/packages/source/k/kiwisolver'],
         'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
     }),
-    ('cycler-0.10.0', '', {
+    ('cycler', '0.10.0', {
         'source_urls': ['https://files.pythonhosted.org/packages/source/c/cycler'],
         'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
     }),


### PR DESCRIPTION
* Added 4 missing Python packages
* Fixed issue with order of dependencies for `six`
* Downgraded `HDF5` to 1.8.x, because 1.10.x releases are not backwards compatible (enough) and do not work.

