### PR TITLE
Fix BEDTools 2.28 easyconfig: add XZ dependency

### DIFF
--- a/easybuild/easyconfigs/b/BEDTools/BEDTools-2.28.0-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/b/BEDTools/BEDTools-2.28.0-GCCcore-7.3.0.eb
@@ -21,6 +21,7 @@ builddependencies = [
 dependencies = [
     ('zlib', '1.2.11'),
     ('bzip2', '1.0.6'),
+    ('XZ', '5.2.5'),
 ]
 
 buildopts = 'CXX="$CXX"'


### PR DESCRIPTION
BEDTools-2.28.0-GCCcore-7.3.0.eb won't build on some clusters due to error:
```
gcc -g -Wall -O2 -I.  -c -o cram/cram_io.o cram/cram_io.c
cram/cram_io.c:61:10: fatal error: lzma.h: No such file or directory
 #include <lzma.h>
          ^~~~~~~~
compilation terminated.
```
The build likely succeeds on other clusters because xz was is already available (e.g. via yum install).