### PR TITLE
Fix VEP 92.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/b/Bio-DB-HTS/Bio-DB-HTS-3.01-foss-2018b-Perl-5.30.0.eb
+++ b/easybuild/easyconfigs/b/Bio-DB-HTS/Bio-DB-HTS-3.01-foss-2018b-Perl-5.30.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'PerlModule'
+
+name = 'Bio-DB-HTS'
+version = '3.01'
+versionsuffix = '-Perl-%(perlver)s'
+
+homepage = 'https://metacpan.org/release/Bio-DB-HTS'
+description = "Read files using HTSlib including BAM/CRAM, Tabix and BCF database files"
+
+toolchain = {'name': 'foss', 'version': '2018b'}
+
+source_urls = ['https://cpan.metacpan.org/authors/id/A/AV/AVULLO/']
+sources = ['Bio-DB-HTS-%(version)s.tar.gz']
+checksums = ['12a6bc1f579513cac8b9167cce4e363655cc8eba26b7d9fe1170dfe95e044f42']
+
+dependencies = [
+    ('Perl', '5.30.0','-bare'),
+    ('BioPerl', '1.7.2', versionsuffix),
+    ('HTSlib', '1.9'),
+]
+
+options = {'modulename': 'Bio::DB::HTS'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s', 'man/man3'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/v/VEP/VEP-92.0-foss-2018b-Perl-5.30.0.eb
+++ b/easybuild/easyconfigs/v/VEP/VEP-92.0-foss-2018b-Perl-5.30.0.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('PerlPlus', '5.30.0','-v19.08.1',('GCCcore','7.3.0')),
     ('BioPerl', '1.7.2', versionsuffix),
     ('HTSlib','1.9'),
-    ('Bio-DB-HTS', '2.11', versionsuffix),
+    ('Bio-DB-HTS', '3.01', versionsuffix),
 ]
 
 moduleclass = 'bio'


### PR DESCRIPTION
Installing `Bio-DB-HTS-2.11-foss-2018b-Perl-5.30.0.eb` on zf-ds fails with error:
```
== FAILED: Installation ended unsuccessfully (build directory: /apps/.tmp/easybuild/builds/BioDBHTS/2.11/foss-2018b-Perl-5.30.0): build failed (first 300 chars): cmd "perl Build test" exited with exit code 2 and output:
t/00load.t ....... ok
t/01bam.t ........ ok
t/02faidx.t ...... ok
t/03cram.t ....... ok
t/04tabix.t ...... ok
t/05vcf.t ........
Failed 130/177 subtests
t/06kseq.t ....... ok
t/07cramwrite.t .. ok
t/08bamwrite.t ... ok
t/09sam.t ........ ok (took 55 sec)
```
logs:
```
[W::bcf_hdr_parse] The first line should be ##fileformat; is the VCF/BCF header broken?
[E::bcf_hdr_parse] Could not parse the header, sample line not found
Error getting VCF file header: No such file or directory at t/10leak.t line 294.
# Looks like your test exited with 2 just after 5.
t/10leak.t .......
Dubious, test returned 2 (wstat 512, 0x200)
Failed 1/6 subtests
```
Installing `Bio-DB-HTS-3.01-foss-2018b-Perl-5.30.0.eb` installs without issues on zf-ds.