### PR TITLE
Patching easyconfigs to work on CentOS 8.5 (spider)

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-7.3.0.eb
@@ -11,7 +11,11 @@ toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e']
+patches = ['Bison-%(version)s_glibc_2.28.patch']
+checksums = [
+    'b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e',  # bison-3.0.4.tar.gz
+    'bdceb534ef7717bdbbd272bbdf154d5a41e8073cd8d49fe0b02540bbdba68a57',  # Bison-3.0.4_glibc_2.28.patch
+]
 
 builddependencies = [
     ('M4', '1.4.18'),

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4.eb
@@ -11,7 +11,7 @@ description = """
  employing LALR(1) parser tables.
 """
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4.eb
@@ -15,7 +15,12 @@ toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e']
+patches = ['Bison-%(version)s_glibc_2.28.patch']
+checksums = [
+    'b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e',  # bison-3.0.4.tar.gz
+    'bdceb534ef7717bdbbd272bbdf154d5a41e8073cd8d49fe0b02540bbdba68a57',  # Bison-3.0.4_glibc_2.28.patch
+]
+
 
 builddependencies = [
     ('M4', '1.4.17'),

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4_glibc_2.28.patch
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4_glibc_2.28.patch
@@ -1,0 +1,31 @@
+patch to avoid problems on systems using glibc 2.28 (or newer)
+author: Esteban Vohringer-Martinezi (Universidad de Concepción)
+diff -ru bison-3.0.4_orig/lib/fseterr.c bison-3.0.4/lib/fseterr.c
+--- bison-3.0.4_orig/lib/fseterr.c	2019-06-19 15:56:23.552533933 -0400
++++ bison-3.0.4/lib/fseterr.c	2019-06-19 15:58:32.757469045 -0400
+@@ -29,7 +29,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+   fp_->_flags |= __SERR;
+diff -ru bison-3.0.4_orig/lib/stdio-impl.h bison-3.0.4/lib/stdio-impl.h
+--- bison-3.0.4_orig/lib/stdio-impl.h	2019-06-19 15:56:23.556533962 -0400
++++ bison-3.0.4/lib/stdio-impl.h	2019-06-19 15:57:44.497120445 -0400
+@@ -19,6 +19,13 @@
+    have different naming conventions, or their access requires some casts.  */
+ 
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
++
+ /* BSD stdio derived implementations.  */
+ 
+ #if defined __NetBSD__                         /* NetBSD */

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0-remove-glibc-ustat.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0-remove-glibc-ustat.patch
@@ -1,0 +1,69 @@
+# ustat.h was removed in glibc 2.28
+# Patch lifted from https://raw.githubusercontent.com/vmware/photon/master/SPECS/gcc/libsanitizer-avoidustat.h-glibc-2.28.patch
+# Lars Viklund, Sun 18 Aug 2019 12:41:26 AM CEST
+From 61f38c64c01a15560026115a157b7021ec67bd3b Mon Sep 17 00:00:00 2001
+From: hjl <hjl@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Thu, 24 May 2018 20:21:54 +0000
+Subject: [PATCH] libsanitizer: Use pre-computed size of struct ustat for Linux
+
+Cherry-pick compiler-rt revision 333213:
+
+<sys/ustat.h> has been removed from glibc 2.28 by:
+
+commit cf2478d53ad7071e84c724a986b56fe17f4f4ca7
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Sun Mar 18 11:28:59 2018 +0800
+
+    Deprecate ustat syscall interface
+
+This patch uses pre-computed size of struct ustat for Linux.
+
+	PR sanitizer/85835
+	* sanitizer_common/sanitizer_platform_limits_posix.cc: Don't
+	include <sys/ustat.h> for Linux.
+	(SIZEOF_STRUCT_USTAT): New.
+	(struct_ustat_sz): Use SIZEOF_STRUCT_USTAT for Linux.
+
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/gcc-7-branch@260688 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ libsanitizer/ChangeLog                            |  8 ++++++++
+ .../sanitizer_platform_limits_posix.cc            | 15 +++++++++++++--
+ 2 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+index 31a5e697eae..8017afd21c5 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -154,7 +154,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <sys/ustat.h>
+ #include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+@@ -247,7 +246,19 @@ namespace __sanitizer {
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
+ #endif // SANITIZER_LINUX && !SANITIZER_ANDROID
+-- 
+2.18.0

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.3.0.eb
@@ -30,6 +30,7 @@ sources = [
 ]
 patches = [
     'GCCcore-6.2.0-fix-find-isl.patch',
+    'GCCcore-7.3.0-remove-glibc-ustat.patch',
 ]
 checksums = [
     'fa06e455ca198ddc11ea4ddf2a394cf7cfb66aa7e0ab98cc1184189f1d405870',  # gcc-7.3.0.tar.gz
@@ -38,6 +39,7 @@ checksums = [
     '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e',  # mpc-1.1.0.tar.gz
     'd59726f34f7852a081fbd3defd1ab2136f174110fc2e0c8d10bb122173fa9ed8',  # isl-0.19.tar.bz2
     '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+    'f3122fd23b9c2490156e51764eb5262b43f438590390c6e769affc0d1abd6bee',  # GCCcore-7.3.0-remove-glibc-ustat.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/g/gettext/gettext-0.21.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.21.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.21'
+
+homepage = 'https://www.gnu.org/software/gettext/'
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+# This is a basic stripped down version of gettext without any
+# dependencies on other packages used as initial builddep for XZ
+# It is the first step in the cyclic dependency chain of
+# XZ -> libxml2 -> gettext -> XZ
+
+toolchain = SYSTEM
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12']
+
+dependencies = [
+#    ('ncurses', '6.2', '', ('GCCcore', '7.3.0')),
+    ('ncurses', '6.2'),
+]
+
+configopts = '--without-emacs --with-included-libxml --without-xz --without-bzip2'
+
+sanity_check_paths = {
+    'files': ['bin/gettext', 'lib/libasprintf.a', 'lib/libasprintf.%s' % SHLIB_EXT,
+              'lib/libgettextpo.a', 'lib/libgettextpo.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/htop/htop-2.2.0-GCCcore-7.3.0-pbp.eb
+++ b/easybuild/easyconfigs/h/htop/htop-2.2.0-GCCcore-7.3.0-pbp.eb
@@ -9,7 +9,7 @@ easyblock = 'ConfigureMake'
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 #
-# Complete example URL: 
+# Complete example URL:
 # https://github.com/hishamhm/htop/archive/2.2.0.tar.gz
 ##
 # Apply patch for:
@@ -26,7 +26,8 @@ checksums = [
 ]
 
 builddependencies = [
-    ('Autotools', '20180311')
+    ('Autotools', '20180311'),
+    ('Python', '2.7.16', '-bare'),     # scripts/MakeHeader.py uses Python 2
 ]
 
 dependencies = [
@@ -45,3 +46,4 @@ sanity_check_paths = {
 }
 
 moduleclass = 'tools'
+

--- a/easybuild/easyconfigs/h/htop/htop-3.1.2-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/h/htop/htop-3.1.2-GCCcore-7.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'htop'
+version = '3.1.2'
+
+description = """An interactive, ncursus-based process viewer by Hisham Muhammad."""
+homepage = 'https://github.com/hishamhm/htop'
+
+toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
+
+source_urls = ['https://github.com/htop-dev/%(name)s/archive/']
+sources = ['%(version)s.tar.gz']
+
+checksums = [
+    'fe9559637c8f21f5fd531a4c072048a404173806acbdad1359c6b82fd87aa001',  # htop-3.1.2.tar.gz
+]
+
+builddependencies = [
+    ('Autotools', '20180311')
+]
+
+dependencies = [
+    ('ncurses', '6.1'),
+]
+
+#
+# The source distro does not contain a configure script out of the box:
+# Execute autogen.sh, which calls various tools from the Autotools module to create the configure script.
+#
+preconfigopts = './autogen.sh && chmod a+x configure && '
+
+sanity_check_paths = {
+    'files': ['bin/htop', 'share/man/man1/htop.1'],
+    'dirs': [''],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -12,7 +12,7 @@ description = """
  functions for including files, running shell commands, doing arithmetic, etc.
 """
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -16,7 +16,11 @@ toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    '3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e',  # m4-1.4.17.tar.gz
+    'd7ae5c4d1bc636456db5f12c54f8f136512605cd92772a2fc3bc8a8b3cf92cca',  # M4-1.4.17_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17_glibc_2.28.patch
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17_glibc_2.28.patch
@@ -1,0 +1,54 @@
+fix problems occuring from changes in glibc 2.28
+https://github.com/coreutils/gnulib/commit/4af4a4a71827c0bc5e0ec67af23edef4f15cee8e
+
+diff -ru m4-1.4.17.orig/lib/freadahead.c m4-1.4.17/lib/freadahead.c
+--- m4-1.4.17.orig/lib/freadahead.c	2019-06-19 15:21:26.897812071 -0400
++++ m4-1.4.17/lib/freadahead.c	2019-06-19 15:25:40.075547063 -0400
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff -ru m4-1.4.17.orig/lib/fseeko.c m4-1.4.17/lib/fseeko.c
+--- m4-1.4.17.orig/lib/fseeko.c	2019-06-19 15:21:26.897812071 -0400
++++ m4-1.4.17/lib/fseeko.c	2019-06-19 15:27:19.368232257 -0400
+@@ -47,7 +47,7 @@
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -121,7 +121,7 @@
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+diff -ru m4-1.4.17.orig/lib/stdio-impl.h m4-1.4.17/lib/stdio-impl.h
+--- m4-1.4.17.orig/lib/stdio-impl.h	2019-06-19 15:21:26.909812152 -0400
++++ m4-1.4.17/lib/stdio-impl.h	2019-06-19 15:29:10.789003521 -0400
+@@ -21,6 +21,14 @@
+ 
+ /* BSD stdio derived implementations.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
++
+ #if defined __NetBSD__                         /* NetBSD */
+ /* Get __NetBSD_Version__.  */
+ # include <sys/param.h>

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.3.0.eb
@@ -3,7 +3,7 @@ easyblock = 'ConfigureMake'
 name = 'M4'
 version = '1.4.18'
 
-homepage = 'http://www.gnu.org/software/m4/m4.html'
+homepage = 'https://www.gnu.org/software/m4/m4.html'
 description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
   although it has some extensions (for example, handling more than 9 positional parameters to macros).
  GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
@@ -12,7 +12,11 @@ toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
+patches = ['M4-%(version)s_glibc_2.28.patch']
+checksums = [
+    'ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab',  # m4-1.4.18.tar.gz
+    'a613c18f00b1a3caa46ae4b8b849a0f4f71095ad860f4fcd6c6bb4ae211681fa',  # M4-1.4.18_glibc_2.28.patch
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.30', '', True)]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
@@ -12,7 +12,7 @@ description = """
  functions for including files, running shell commands, doing arithmetic, etc.
 """
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18.eb
@@ -16,7 +16,11 @@ toolchain = SYSTEM
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
+patches = ['M4-1.4.18_glibc_2.28.patch']
+checksums = [
+    'ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab',  # m4-1.4.18.tar.gz
+    'a613c18f00b1a3caa46ae4b8b849a0f4f71095ad860f4fcd6c6bb4ae211681fa',  # M4-1.4.18_glibc_2.28.patch
+]
 
 # '-fgnu89-inline' is required to avoid linking errors with older glibc's,
 # see https://github.com/easybuilders/easybuild-easyconfigs/issues/529

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
@@ -1,0 +1,56 @@
+fix problems occuring from changes in glibc 2.28
+https://github.com/coreutils/gnulib/commit/4af4a4a71827c0bc5e0ec67af23edef4f15cee8e
+
+diff -Naur m4-1.4.18_old/lib/freadahead.c m4-1.4.18/lib/freadahead.c
+--- m4-1.4.18_old/lib/freadahead.c      2019-01-08 15:26:47.835617107 +0100
++++ m4-1.4.18/lib/freadahead.c  2019-01-08 15:29:50.827211620 +0100
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+
+diff -Naur m4-1.4.18_old/lib/fseeko.c m4-1.4.18/lib/fseeko.c
+--- m4-1.4.18_old/lib/fseeko.c  2019-01-08 15:26:47.831617117 +0100
++++ m4-1.4.18/lib/fseeko.c      2019-01-08 15:29:50.835211605 +0100
+@@ -47,7 +47,7 @@
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+
+diff -Naur m4-1.4.18_old/lib/stdio-impl.h m4-1.4.18/lib/stdio-impl.h
+--- m4-1.4.18_old/lib/stdio-impl.h      2019-01-08 15:26:47.831617117 +0100
++++ m4-1.4.18/lib/stdio-impl.h  2019-01-08 15:29:50.835211605 +0100
+@@ -21,6 +21,13 @@
+ 
+ /* BSD stdio derived implementations.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
++
+ #if defined __NetBSD__                         /* NetBSD */
+ /* Get __NetBSD_Version__.  */
+ # include <sys/param.h>
+

--- a/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-7.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-7.3.0-bare.eb
@@ -43,7 +43,7 @@ exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
     'source_urls': [PYPI_SOURCE],
-    'use_pip': False,
+    'use_pip': True,
 }
 
 #

--- a/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-7.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.7.4-GCCcore-7.3.0-bare.eb
@@ -43,7 +43,7 @@ exts_default_options = {
     'download_dep_fail': True,
     'sanity_pip_check': True,
     'source_urls': [PYPI_SOURCE],
-    'use_pip': True,
+    'use_pip': False,
 }
 
 #


### PR DESCRIPTION
- GCCcore 7.3.0 version of glibc 2.28 patch - the higher GCCcore versions (8.x and higher) are working without this issue
- glibc 2.28 patches were applied also to latest Bison and M4 versions
- htop: fixed v2.2.0 as its installation really depends on Python2, added htop 3.1.2 (pointing from to new official repository, which does not need Python2)
- creating gettext to avoid crashing on a fresh system due to the chicken and egg - this version omits some functionality and is same on how it was deployed on GS 